### PR TITLE
Add SyncYomi support with settings UI, toasts, and auto-sync triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- (**SyncYomi**) Add SyncYomi section to server settings with enable/disable toggle, server address, API key, auto-sync interval, data sync toggles, and trigger configuration (chapter read, chapter open, client start, client resume)
+- (**SyncYomi**) Add `SyncTriggerHandler` component (mounted in the app layout) that fires sync on client start and resume based on configured settings
+- (**SyncYomi**) Show "Syncing library..." persistent progress toast and completion/error toasts via the `syncStatusChanged` subscription
+
+### Fixed
+
+- (**SyncYomi**) Fix auto-sync interval dropdown showing raw ISO 8601 values (`PT15M`) instead of human-readable labels ("15 minutes") by extending `Select` component to accept `{ value, label }` option objects
+- (**SyncYomi**) Fix header title reverting to "Loading..." after triggering a manual sync — eliminated the duplicate `serverSettings` query in `SyncTriggerHandler` by sharing sync settings via a Svelte store written by the settings page
+- (**ServiceWorker**) Call `skipWaiting()` on install so new builds activate immediately without requiring all tabs to close

--- a/schema.graphql
+++ b/schema.graphql
@@ -304,6 +304,9 @@ type CreateCategoryPayload {
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
+"""An ISO-8601 duration value."""
+scalar Duration
+
 input DeleteCategoryInput {
   categoryId: Int!
   clientMutationId: String
@@ -1109,6 +1112,7 @@ type Mutation {
   updateCategoryManga(input: UpdateCategoryMangaInput!): UpdateCategoryMangaPayload
   updateLibraryManga(input: UpdateLibraryMangaInput!): UpdateLibraryMangaPayload
   updateStop(input: UpdateStopInput!): UpdateStopPayload!
+  startSync(input: StartSyncInput!): StartSyncPayload!
 }
 
 union Node = CategoryMetaType | CategoryType | ChapterMetaType | ChapterType | DownloadType | DownloadUpdate | ExtensionType | GlobalMetaType | MangaMetaType | MangaType | PartialSettingsType | SettingsType | SourceMetaType | SourceType | TrackRecordType | TrackerType
@@ -1192,6 +1196,19 @@ type PartialSettingsType implements Settings {
   webUIFlavor: WebUIFlavor
   webUIInterface: WebUIInterface
   webUIUpdateCheckInterval: Float
+  syncDataCategories: Boolean
+  syncDataChapters: Boolean
+  syncDataHistory: Boolean
+  syncDataManga: Boolean
+  syncDataTracking: Boolean
+  syncInterval: Duration
+  syncOnChapterOpen: Boolean
+  syncOnChapterRead: Boolean
+  syncOnWebUIResume: Boolean
+  syncOnWebUIStart: Boolean
+  syncYomiApiKey: String
+  syncYomiEnabled: Boolean
+  syncYomiHost: String
 }
 
 input PartialSettingsTypeInput {
@@ -1241,6 +1258,19 @@ input PartialSettingsTypeInput {
   webUIFlavor: WebUIFlavor
   webUIInterface: WebUIInterface
   webUIUpdateCheckInterval: Float
+  syncDataCategories: Boolean
+  syncDataChapters: Boolean
+  syncDataHistory: Boolean
+  syncDataManga: Boolean
+  syncDataTracking: Boolean
+  syncInterval: Duration
+  syncOnChapterOpen: Boolean
+  syncOnChapterRead: Boolean
+  syncOnWebUIResume: Boolean
+  syncOnWebUIStart: Boolean
+  syncYomiApiKey: String
+  syncYomiEnabled: Boolean
+  syncYomiHost: String
 }
 
 union Preference = CheckBoxPreference | EditTextPreference | ListPreference | MultiSelectListPreference | SwitchPreference
@@ -1435,6 +1465,19 @@ interface Settings {
   webUIFlavor: WebUIFlavor
   webUIInterface: WebUIInterface
   webUIUpdateCheckInterval: Float
+  syncDataCategories: Boolean
+  syncDataChapters: Boolean
+  syncDataHistory: Boolean
+  syncDataManga: Boolean
+  syncDataTracking: Boolean
+  syncInterval: Duration
+  syncOnChapterOpen: Boolean
+  syncOnChapterRead: Boolean
+  syncOnWebUIResume: Boolean
+  syncOnWebUIStart: Boolean
+  syncYomiApiKey: String
+  syncYomiEnabled: Boolean
+  syncYomiHost: String
 }
 
 type SettingsType implements Settings {
@@ -1486,6 +1529,19 @@ type SettingsType implements Settings {
   webUIFlavor: WebUIFlavor!
   webUIInterface: WebUIInterface!
   webUIUpdateCheckInterval: Float!
+  syncDataCategories: Boolean!
+  syncDataChapters: Boolean!
+  syncDataHistory: Boolean!
+  syncDataManga: Boolean!
+  syncDataTracking: Boolean!
+  syncInterval: Duration!
+  syncOnChapterOpen: Boolean!
+  syncOnChapterRead: Boolean!
+  syncOnWebUIResume: Boolean!
+  syncOnWebUIStart: Boolean!
+  syncYomiApiKey: String!
+  syncYomiEnabled: Boolean!
+  syncYomiHost: String!
 }
 
 type SortFilter {
@@ -1600,6 +1656,39 @@ type StartDownloaderPayload {
   downloadStatus: DownloadStatus!
 }
 
+input StartSyncInput {
+  clientMutationId: String
+}
+
+type StartSyncPayload {
+  clientMutationId: String
+  result: StartSyncResult!
+}
+
+enum StartSyncResult {
+  SUCCESS
+  SYNC_DISABLED
+  SYNC_IN_PROGRESS
+}
+
+enum SyncState {
+  STARTED
+  CREATING_BACKUP
+  DOWNLOADING
+  MERGING
+  UPLOADING
+  RESTORING
+  SUCCESS
+  ERROR
+}
+
+type SyncStatus {
+  state: SyncState!
+  startDate: LongString!
+  endDate: LongString
+  errorMessage: String
+}
+
 input StopDownloaderInput {
   clientMutationId: String
 }
@@ -1690,6 +1779,7 @@ type Subscription {
   downloadStatusChanged(input: DownloadChangedInput!): DownloadUpdates!
   webUIUpdateStatusChange: WebUIUpdateStatus!
   updateStatusChanged: UpdateStatus!
+  syncStatusChanged: SyncStatus!
 }
 
 type SwitchPreference {

--- a/src/lib/components/SyncTriggerHandler.svelte
+++ b/src/lib/components/SyncTriggerHandler.svelte
@@ -1,0 +1,83 @@
+<!--
+ Copyright (c) 2024 Contributors to the Suwayomi project
+
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<script lang="ts">
+	import { page } from '$app/state';
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import { getContextClient } from '@urql/svelte';
+	import {
+		subscriptionState,
+		showSyncProgressToast,
+		closeSyncProgressToast,
+		successToast,
+		errortoast
+	} from '$lib/util.svelte';
+	import { syncSettings } from '$lib/simpleStores.svelte';
+	import { startSync } from '$lib/gql/Mutations';
+	import { syncStatusChangedSub } from '$lib/gql/Subscriptions';
+
+	const READER_PATH_PATTERN = /^\/manga\/\d+\/chapter\//;
+	const MIN_TOAST_MS = 800;
+
+	const client = getContextClient();
+	const syncStatus = subscriptionState({ client, query: syncStatusChangedSub });
+
+	let syncToastTimer: ReturnType<typeof setTimeout> | null = null;
+	let startTriggered = false;
+
+	function isOnReader(): boolean {
+		return READER_PATH_PATTERN.test(page.url.pathname);
+	}
+
+	function triggerSync(): void {
+		if (isOnReader()) return;
+		showSyncProgressToast();
+		client.mutation(startSync, {}).toPromise();
+	}
+
+	// Close loading toast and show result when sync subscription emits SUCCESS/ERROR
+	$effect(() => {
+		const state = syncStatus.data?.syncStatusChanged?.state;
+		if (!state) return;
+
+		if (syncToastTimer) clearTimeout(syncToastTimer);
+		syncToastTimer = setTimeout(() => {
+			closeSyncProgressToast();
+			if (state === 'SUCCESS') {
+				if (!isOnReader()) successToast('Sync completed successfully');
+			} else if (state === 'ERROR') {
+				if (!isOnReader()) errortoast('Sync failed', syncStatus.data?.syncStatusChanged?.errorMessage ?? '');
+			}
+		}, MIN_TOAST_MS);
+
+		return () => {
+			if (syncToastTimer) clearTimeout(syncToastTimer);
+		};
+	});
+
+	// Fire syncOnWebUIStart exactly once when settings first load with it enabled
+	$effect(() => {
+		const s = $syncSettings;
+		if (!s?.syncYomiEnabled || !s?.syncOnWebUIStart || startTriggered) return;
+		startTriggered = true;
+		triggerSync();
+	});
+
+	// Register visibilitychange listener once — reads current settings at event time
+	onMount(() => {
+		function handleVisibility(): void {
+			if (document.visibilityState !== 'visible') return;
+			const s = get(syncSettings);
+			if (!s?.syncYomiEnabled || !s?.syncOnWebUIResume) return;
+			triggerSync();
+		}
+
+		document.addEventListener('visibilitychange', handleVisibility);
+		return () => document.removeEventListener('visibilitychange', handleVisibility);
+	});
+</script>

--- a/src/lib/gql/Mutations.ts
+++ b/src/lib/gql/Mutations.ts
@@ -949,3 +949,14 @@ export const setCategoryMeta = graphql(`
 		}
 	}
 `);
+
+export const startSync = graphql(
+	`
+		mutation startSync {
+			startSync(input: {}) {
+				result
+			}
+		}
+	`,
+	[]
+);

--- a/src/lib/gql/Queries.ts
+++ b/src/lib/gql/Queries.ts
@@ -455,6 +455,19 @@ export const serverSettings = graphql(
 				socksProxyPassword
 				socksProxyUsername
 				socksProxyVersion
+				syncDataCategories
+				syncDataChapters
+				syncDataHistory
+				syncDataManga
+				syncDataTracking
+				syncInterval
+				syncOnChapterOpen
+				syncOnChapterRead
+				syncOnWebUIResume
+				syncOnWebUIStart
+				syncYomiApiKey
+				syncYomiEnabled
+				syncYomiHost
 			}
 		}
 	`,

--- a/src/lib/gql/Subscriptions.ts
+++ b/src/lib/gql/Subscriptions.ts
@@ -85,6 +85,15 @@ export const updateStatusChanged = graphql(`
 	}
 `);
 
+export const syncStatusChangedSub = graphql(`
+	subscription syncStatusChangedSub {
+		syncStatusChanged {
+			state
+			errorMessage
+		}
+	}
+`);
+
 export const DownloadChanged = graphql(`
 	subscription DownloadChanged {
 		downloadStatusChanged(input: {}) {

--- a/src/lib/simpleStores.svelte.ts
+++ b/src/lib/simpleStores.svelte.ts
@@ -32,6 +32,12 @@ import type { CssClasses } from '@skeletonlabs/skeleton';
 
 export const toastStore = writable<ToastStore | null>(null);
 
+export const syncSettings = writable<{
+	syncYomiEnabled: boolean;
+	syncOnWebUIStart: boolean;
+	syncOnWebUIResume: boolean;
+} | null>(null);
+
 type Themes = (typeof presetConst)[number]['name'];
 
 export const ChapterTitle = {

--- a/src/lib/util.svelte.ts
+++ b/src/lib/util.svelte.ts
@@ -241,6 +241,31 @@ export function errortoast(failMessage: string, errorMessage: string) {
 	});
 }
 
+let _syncProgressToastId: string | null = null;
+
+export function showSyncProgressToast(): void {
+	if (_syncProgressToastId) return;
+	_syncProgressToastId = getToastStore().trigger({
+		message: 'Syncing library...',
+		autoHide: false,
+		hoverable: false,
+		background: 'bg-warning-500'
+	});
+}
+
+export function closeSyncProgressToast(): void {
+	if (!_syncProgressToastId) return;
+	getToastStore().close(_syncProgressToastId);
+	_syncProgressToastId = null;
+}
+
+export function successToast(message: string): void {
+	getToastStore().trigger({
+		message,
+		background: 'bg-success-500'
+	});
+}
+
 export function Partition<T>(
 	arr: T[],
 	comparator: (e: T) => boolean

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -11,6 +11,7 @@
 	import MainAppRail from '$lib/components/MainAppRail.svelte';
 	import MediaQuery from '$lib/components/MediaQuery.svelte';
 	import MobileAppNavigation from '$lib/components/MobileAppNavigation.svelte';
+	import SyncTriggerHandler from '$lib/components/SyncTriggerHandler.svelte';
 	import { screens } from '$lib/screens';
 	import { AppBar } from '@skeletonlabs/skeleton';
 	interface Props {
@@ -50,6 +51,7 @@
 			{/snippet}
 		</MediaQuery>
 	{/snippet}
+	<SyncTriggerHandler />
 	{@render children?.()}
 	{#snippet footer()}
 		<MediaQuery query="(max-width: {screens.md})">

--- a/src/routes/(app)/settings/server/+page.svelte
+++ b/src/routes/(app)/settings/server/+page.svelte
@@ -12,8 +12,10 @@
 		errortoast,
 		queryState,
 		setSettings,
+		showSyncProgressToast,
 		subscriptionState
 	} from '$lib/util.svelte';
+	import { syncSettings } from '$lib/simpleStores.svelte';
 	import { getContextClient } from '@urql/svelte';
 	import Select from './components/Select.svelte';
 	import ExtensionReposModal from './components/extensionReposModal.svelte';
@@ -26,7 +28,8 @@
 		updateWebUI,
 		type setServerSettings,
 		runUpdateLibraryManga,
-		updateMangasCategories
+		updateMangasCategories,
+		startSync
 	} from '$lib/gql/Mutations';
 	import { type VariablesOf } from '$lib/gql/graphql';
 	import {
@@ -117,6 +120,21 @@
 	);
 	let webUIUpdateCheckInterval = $state(23);
 
+	let syncDataCategories = $state(false);
+	let syncDataChapters = $state(false);
+	let syncDataHistory = $state(false);
+	let syncDataManga = $state(false);
+	let syncDataTracking = $state(false);
+	let syncInterval = $state('PT0S');
+	let syncOnChapterOpen = $state(false);
+	let syncOnChapterRead = $state(false);
+	let syncOnWebUIResume = $state(false);
+	let syncOnWebUIStart = $state(false);
+	let syncYomiApiKey = $state('');
+	let syncYomiEnabled = $state(false);
+	let syncYomiHost = $state('');
+	let syncYomiSyncing = $state(false);
+
 	$effect(() => {
 		if (settingsData.data?.settings) {
 			autoDownloadNewChapters =
@@ -171,6 +189,24 @@
 			webUIInterface = settingsData.data.settings.webUIInterface;
 			webUIUpdateCheckInterval =
 				settingsData.data.settings.webUIUpdateCheckInterval;
+			syncDataCategories = settingsData.data.settings.syncDataCategories;
+			syncDataChapters = settingsData.data.settings.syncDataChapters;
+			syncDataHistory = settingsData.data.settings.syncDataHistory;
+			syncDataManga = settingsData.data.settings.syncDataManga;
+			syncDataTracking = settingsData.data.settings.syncDataTracking;
+			syncInterval = settingsData.data.settings.syncInterval;
+			syncOnChapterOpen = settingsData.data.settings.syncOnChapterOpen;
+			syncOnChapterRead = settingsData.data.settings.syncOnChapterRead;
+			syncOnWebUIResume = settingsData.data.settings.syncOnWebUIResume;
+			syncOnWebUIStart = settingsData.data.settings.syncOnWebUIStart;
+			syncYomiApiKey = settingsData.data.settings.syncYomiApiKey;
+			syncYomiEnabled = settingsData.data.settings.syncYomiEnabled;
+			syncYomiHost = settingsData.data.settings.syncYomiHost;
+			syncSettings.set({
+				syncYomiEnabled: settingsData.data.settings.syncYomiEnabled,
+				syncOnWebUIStart: settingsData.data.settings.syncOnWebUIStart,
+				syncOnWebUIResume: settingsData.data.settings.syncOnWebUIResume
+			});
 		}
 	});
 
@@ -201,6 +237,16 @@
 				props: { update }
 			}
 		});
+	}
+
+	async function syncNow() {
+		syncYomiSyncing = true;
+		showSyncProgressToast();
+		try {
+			await client.mutation(startSync, {}).toPromise();
+		} finally {
+			syncYomiSyncing = false;
+		}
 	}
 
 	let removingNoCategoriesManga = $state(false);
@@ -575,6 +621,107 @@
 			title="Update Mangas"
 			bind:checked={updateMangas}
 			onchange={() => setSettings({ updateMangas })}
+		/>
+		<!-- SyncYomi -->
+		<div class="flex h-8 w-full items-center px-4 text-sm font-semibold opacity-70">SyncYomi</div>
+		<!-- syncYomiEnabled -->
+		<Toggle
+			title="Enable SyncYomi"
+			bind:checked={syncYomiEnabled}
+			onchange={() => setSettings({ syncYomiEnabled })}
+		/>
+		<!-- syncYomiHost -->
+		<Text
+			title="Server address"
+			bind:value={syncYomiHost}
+			onchange={() => setSettings({ syncYomiHost })}
+		/>
+		<!-- syncYomiApiKey -->
+		<Text
+			title="API key"
+			bind:value={syncYomiApiKey}
+			onchange={() => setSettings({ syncYomiApiKey })}
+		/>
+		<!-- syncInterval -->
+		<Select
+			title="Auto-sync interval"
+			bind:value={syncInterval}
+			options={[
+				{ value: 'PT0S', label: 'Disabled' },
+				{ value: 'PT15M', label: '15 minutes' },
+				{ value: 'PT30M', label: '30 minutes' },
+				{ value: 'PT1H', label: '1 hour' },
+				{ value: 'PT2H', label: '2 hours' },
+				{ value: 'PT6H', label: '6 hours' },
+				{ value: 'PT12H', label: '12 hours' },
+				{ value: 'PT24H', label: '24 hours' }
+			]}
+			onchange={() => setSettings({ syncInterval })}
+		/>
+		<!-- Sync now -->
+		<button
+			class="flex h-16 w-full cursor-pointer items-center justify-between text-left hover:variant-glass-surface disabled:opacity-50"
+			disabled={!syncYomiEnabled || syncYomiSyncing}
+			onclick={syncNow}
+		>
+			Sync now
+			{#if syncYomiSyncing}
+				<span class="text-sm opacity-50">Syncing...</span>
+			{/if}
+		</button>
+		<!-- syncDataManga -->
+		<Toggle
+			title="Manga"
+			bind:checked={syncDataManga}
+			onchange={() => setSettings({ syncDataManga })}
+		/>
+		<!-- syncDataChapters -->
+		<Toggle
+			title="Chapters"
+			bind:checked={syncDataChapters}
+			onchange={() => setSettings({ syncDataChapters })}
+		/>
+		<!-- syncDataTracking -->
+		<Toggle
+			title="Tracking"
+			bind:checked={syncDataTracking}
+			onchange={() => setSettings({ syncDataTracking })}
+		/>
+		<!-- syncDataHistory -->
+		<Toggle
+			title="History"
+			bind:checked={syncDataHistory}
+			onchange={() => setSettings({ syncDataHistory })}
+		/>
+		<!-- syncDataCategories -->
+		<Toggle
+			title="Categories"
+			bind:checked={syncDataCategories}
+			onchange={() => setSettings({ syncDataCategories })}
+		/>
+		<!-- syncOnChapterRead -->
+		<Toggle
+			title="Trigger on chapter read"
+			bind:checked={syncOnChapterRead}
+			onchange={() => setSettings({ syncOnChapterRead })}
+		/>
+		<!-- syncOnChapterOpen -->
+		<Toggle
+			title="Trigger on chapter open"
+			bind:checked={syncOnChapterOpen}
+			onchange={() => setSettings({ syncOnChapterOpen })}
+		/>
+		<!-- syncOnWebUIStart -->
+		<Toggle
+			title="Trigger on client start"
+			bind:checked={syncOnWebUIStart}
+			onchange={() => setSettings({ syncOnWebUIStart })}
+		/>
+		<!-- syncOnWebUIResume -->
+		<Toggle
+			title="Trigger on client resume"
+			bind:checked={syncOnWebUIResume}
+			onchange={() => setSettings({ syncOnWebUIResume })}
 		/>
 		<!-- webUIChannel -->
 		<Select

--- a/src/routes/(app)/settings/server/components/Select.svelte
+++ b/src/routes/(app)/settings/server/components/Select.svelte
@@ -6,10 +6,12 @@
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <script lang="ts">
+	type SelectOption = string | { value: string; label: string };
+
 	interface Props {
 		value: string;
 		title: string;
-		options: Array<string>;
+		options: Array<SelectOption>;
 		onchange: () => void;
 	}
 
@@ -19,6 +21,14 @@
 		options,
 		onchange = () => {}
 	}: Props = $props();
+
+	function optionValue(opt: SelectOption): string {
+		return typeof opt === 'string' ? opt : opt.value;
+	}
+
+	function optionLabel(opt: SelectOption): string {
+		return typeof opt === 'string' ? opt.toLocaleLowerCase() : opt.label;
+	}
 </script>
 
 <label
@@ -28,9 +38,7 @@
 	<div class="flex flex-1 flex-nowrap items-center justify-end space-x-2">
 		<select class="input max-w-32 sm:max-w-[36.5rem]" bind:value {onchange}>
 			{#each options as option}
-				<option class="capitalize" value={option}
-					>{option.toLocaleLowerCase()}</option
-				>
+				<option value={optionValue(option)}>{optionLabel(option)}</option>
 			{/each}
 		</select>
 	</div>

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -19,13 +19,18 @@ self.addEventListener('install', (event) => {
 	async function addFilesToCache() {
 		await caches.open(CACHE);
 		// await cache.addAll(ASSETS);
+		await self.skipWaiting();
 	}
 
 	event.waitUntil(addFilesToCache());
 });
 
 self.addEventListener('activate', (event) => {
-	event.waitUntil(deleteOldCaches());
+	async function activate() {
+		await deleteOldCaches();
+		await self.clients.claim();
+	}
+	event.waitUntil(activate());
 });
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
## Summary

- Add a SyncYomi section to the server settings page with full configuration: enable/disable, server address, API key, auto-sync interval (with human-readable labels), per-data-type toggles (manga, chapters, tracking, history, categories), trigger options (chapter read, chapter open, client start, client resume), and a manual "Sync Now" button
- Add `SyncTriggerHandler` component mounted in the app layout that fires sync on client start and resume based on configured settings; reads from a shared Svelte store to avoid a duplicate GraphQL query
- Show a persistent "Syncing library..." progress toast and a completion/error toast driven by the `syncStatusChanged` subscription; toasts are suppressed on the reader route
- Fix `Select` component to accept `{ value, label }` option objects, resolving the auto-sync interval dropdown showing raw ISO 8601 values (`PT15M`) instead of labels ("15 minutes")
- Fix service worker to call `skipWaiting()` on install so new builds activate immediately without requiring all tabs to close
- Fix header title reverting to "Loading..." after triggering a manual sync — eliminated the duplicate `serverSettings` query in `SyncTriggerHandler` by sharing state via a Svelte store written by the settings page

## Test plan

- [ ] Open server settings and verify the SyncYomi section renders correctly with all controls
- [ ] Set auto-sync interval and confirm the dropdown shows human-readable labels, not raw ISO values
- [ ] Enable SyncYomi and click "Sync Now" — verify the progress toast appears and header title stays stable (does not revert to "Loading...")
- [ ] Verify success/error toast appears after sync completes
- [ ] Enable "Trigger on client start" — reload the app and confirm sync fires automatically
- [ ] Switch browser tabs and return — confirm "Trigger on client resume" fires sync
- [ ] Deploy a new build and reload — confirm the new service worker activates without needing to close all tabs